### PR TITLE
[Fix] fix errors on two edge cases on onboarding (string length, user…

### DIFF
--- a/feature/login/src/main/java/com/posomo/saltit/login/LoginFragment.kt
+++ b/feature/login/src/main/java/com/posomo/saltit/login/LoginFragment.kt
@@ -24,11 +24,14 @@ class LoginFragment : BaseFragment<FragmentOnboardingChildThirdBinding>(R.layout
         val userIdealAvgLunchPrice = (activity as ActivityUtil).getUserIdealAvgLunchPriceInLocal(0)
         val userSavingLunchPrice = ((userCurrentAvgLunchPrice - userIdealAvgLunchPrice)*30).toString()
 
-        if(userSavingLunchPrice.length ==5 ) {
+        if(userSavingLunchPrice.length == 5 ) {
             binding.onboarding3MonthlySavingMoney.text = userSavingLunchPrice.substring(0,2) + ",000"
         }
-        else {
+        else if(userSavingLunchPrice.length == 6) {
             binding.onboarding3MonthlySavingMoney.text = userSavingLunchPrice.substring(0,3) + ",000"
+        }
+        else {
+            binding.onboarding3MonthlySavingMoney.text = "15,000"
         }
 
         binding.loginBtn.setOnClickListener {

--- a/feature/login/src/main/java/com/posomo/saltit/login/onboarding/OnboardingChildFirstFragment.kt
+++ b/feature/login/src/main/java/com/posomo/saltit/login/onboarding/OnboardingChildFirstFragment.kt
@@ -46,9 +46,11 @@ class OnboardingChildFirstFragment : BaseFragment<FragmentOnboardingChildFirstBi
             userOldLunchPrice /= 1000
             userOldLunchPrice *= 1000
 
-            (activity as ActivityUtil).setUserCurrentAvgLunchPriceInLocal(userOldLunchPrice)
+            if(userOldLunchPrice != 0 ) {
+                (activity as ActivityUtil).setUserCurrentAvgLunchPriceInLocal(userOldLunchPrice)
 
-            viewPager?.currentItem = 1
+                viewPager?.currentItem = 1
+            }
         }
 
         binding.onboardingUserLunchPriceSeekbar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener{

--- a/feature/login/src/main/java/com/posomo/saltit/login/onboarding/OnboardingChildSecondFragment.kt
+++ b/feature/login/src/main/java/com/posomo/saltit/login/onboarding/OnboardingChildSecondFragment.kt
@@ -29,7 +29,6 @@ class OnboardingChildSecondFragment : BaseFragment<FragmentOnboardingChildSecond
             )
         )
 
-        val viewPager = activity?.findViewById<ViewPager2>(R.id.viewPager)
         val textResourceId = R.string.onboarding2_question_text_head
         val textData: String = getString(textResourceId)
         val builder = SpannableStringBuilder(textData)
@@ -48,10 +47,11 @@ class OnboardingChildSecondFragment : BaseFragment<FragmentOnboardingChildSecond
             userTargetLunchPrice /= 1000
             userTargetLunchPrice *= 1000
 
-            (activity as ActivityUtil).setUserIdealAvgLunchPriceInLocal(userTargetLunchPrice)
+            if(userTargetLunchPrice != 0) {
+                (activity as ActivityUtil).setUserIdealAvgLunchPriceInLocal(userTargetLunchPrice)
 
-            //viewPager?.currentItem = 2
-            findNavController().navigate(R.id.action_onboardingFragment_to_loginFragment)
+                findNavController().navigate(R.id.action_onboardingFragment_to_loginFragment)
+            }
         }
 
         binding.onboarding2UserLunchPriceSeekbar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener {


### PR DESCRIPTION
문제 상황이었던 
1. 사용자가 평균적으로 지출하고 있는 점심가격과 앞으로 지출하고자 하는 목표 점심 가격이 동일할 때, LoginFragment에서 보여주고 있는 한 달에 절약할 수 있는 점심값의 string 길이 예외 처리 안하고 있음
2. 사용자로부터 가격을 안받았을 때의 예외 case 막지 않고 있음

모두 해결하였습니다.

**Solution**
1. 일반적인 유저의 입장에서 사용자가 평균적으로 지출하고 있는 점심가격과 앞으로 지출하고자 하는 목표 점심 가격이 동일한 경우는 이미 적정선의 점심값을 지출하고 있는 유저라고 판단하여 솔팃을 지금의 건강한 소비패턴을 더욱 보조할 수 있는 도구로 여길 것이라고 결론내림.
따라서 이 경우에는 조금 더 동기부여를 하고자 하루 500원이라도 절약해보자 라는 목표의식을 독려하기 위해 하루 500원 save*30일 = 15,000원을 한달에 솔팃과 함께 save해보자고 제안하고 있음
2. 사용자가 seekbar를 움직이지 않아 가격이 설정되어있지 않다면 '다음'버튼을 눌러도 다음 페이지로 이동하지 않도록 막아둠